### PR TITLE
Track restaurant closures using Google Places API (v2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,10 @@ jobs:
       run: python update_postcode.py
     - name: Get locations
       run: python get_locations.py
+    - name: Check closures
+      # Closure data is nice-to-have; never block the weekly map update on it
+      continue-on-error: true
+      run: python check_closures.py
     - name: Analyze sentiment
       run: python compute_sentiment.py
     - name: Generate map

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,8 @@ jobs:
     env:
       GUARDIAN_API_KEY: ${{ secrets.GUARDIAN_API_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      GOOGLE_MAPS_API_KEY_GEOCODE: ${{ secrets.GOOGLE_MAPS_API_KEY_GEOCODE }}
+      GOOGLE_MAPS_API_KEY_PLACES: ${{ secrets.GOOGLE_MAPS_API_KEY_PLACES }}
     permissions:
       # Give the default GITHUB_TOKEN write permission to commit and push the
       # added or changed files to the repository.

--- a/check_closures.py
+++ b/check_closures.py
@@ -1,0 +1,133 @@
+import sqlite3
+import requests
+import os
+import time
+from datetime import datetime, timedelta
+
+# Google Maps Platform terms only permit caching most Places fields for up to
+# 30 days, so every restaurant must be re-checked at least that often.
+RECHECK_DAYS = 30
+COMMIT_EVERY = 25
+
+# Connect to the database
+conn = sqlite3.connect('reviews.db')
+c = conn.cursor()
+
+# Google Maps API key
+api_key = os.environ.get('GOOGLE_MAPS_API_KEY')
+if not api_key:
+    try:
+        with open('.env') as f:
+            for line in f:
+                if line.startswith('GOOGLE_MAPS_API_KEY='):
+                    api_key = line.strip().split('=', 1)[1]
+                    break
+    except FileNotFoundError:
+        pass
+
+if not api_key:
+    print("ERROR: GOOGLE_MAPS_API_KEY not found")
+    exit(1)
+
+# Add closure columns if they don't exist
+c.execute("PRAGMA table_info(reviews)")
+columns = [column[1] for column in c.fetchall()]
+if 'closed' not in columns:
+    c.execute("ALTER TABLE reviews ADD COLUMN closed INTEGER DEFAULT 0")
+if 'closed_date' not in columns:
+    c.execute("ALTER TABLE reviews ADD COLUMN closed_date TEXT")
+if 'closure_checked_at' not in columns:
+    c.execute("ALTER TABLE reviews ADD COLUMN closure_checked_at TEXT")
+conn.commit()
+
+
+def find_place_status(name, lat, lng):
+    """Look up a place's business_status via the Places Find Place API.
+
+    Returns the status string, or None if the place could not be found.
+    Raises for quota/auth errors so the run stops instead of burning quota.
+    """
+    url = "https://maps.googleapis.com/maps/api/place/findplacefromtext/json"
+    params = {
+        "input": name,
+        "inputtype": "textquery",
+        "fields": "business_status",
+        "locationbias": f"point:{lat},{lng}",
+        "key": api_key,
+    }
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    status = data.get("status")
+
+    if status in ("OVER_QUERY_LIMIT", "REQUEST_DENIED"):
+        raise RuntimeError(f"Places API error: {status} - {data.get('error_message', '')}")
+    if status == "OK" and data.get("candidates"):
+        return data["candidates"][0].get("business_status")
+    return None
+
+
+# Check restaurants that have never been checked, or whose last check is
+# older than the permitted cache window. Progress is committed as we go, so
+# a failed run resumes where it left off.
+cutoff = (datetime.now() - timedelta(days=RECHECK_DAYS)).isoformat()
+rows = c.execute(
+    "SELECT id, title, location_lat, location_long, closed FROM reviews "
+    "WHERE location_lat IS NOT NULL AND location_long IS NOT NULL "
+    "AND (closure_checked_at IS NULL OR closure_checked_at < ?) "
+    "ORDER BY closure_checked_at IS NOT NULL, closure_checked_at",
+    (cutoff,),
+).fetchall()
+
+if not rows:
+    print("All closure statuses are fresh (checked within "
+          f"{RECHECK_DAYS} days). Nothing to do.")
+    conn.close()
+    exit(0)
+
+print(f"Checking closure status for {len(rows)} restaurants...")
+
+newly_closed = 0
+not_found = 0
+for i, (review_id, title, lat, lng, was_closed) in enumerate(rows, 1):
+    try:
+        status = find_place_status(title, lat, lng)
+    except requests.RequestException as e:
+        # Transient network problem: skip this row (it stays due for
+        # checking) and carry on.
+        print(f"Request failed for '{title}': {e}")
+        continue
+
+    now = datetime.now().isoformat()
+    if status == "CLOSED_PERMANENTLY":
+        if not was_closed:
+            c.execute(
+                "UPDATE reviews SET closed = 1, closed_date = ?, closure_checked_at = ? WHERE id = ?",
+                (now[:10], now, review_id),
+            )
+            newly_closed += 1
+            print(f"CLOSED: {title}")
+        else:
+            c.execute("UPDATE reviews SET closure_checked_at = ? WHERE id = ?", (now, review_id))
+    elif status is not None:
+        c.execute(
+            "UPDATE reviews SET closed = 0, closed_date = NULL, closure_checked_at = ? WHERE id = ?",
+            (now, review_id),
+        )
+    else:
+        # Place not found: keep whatever status we had rather than guessing.
+        not_found += 1
+        c.execute("UPDATE reviews SET closure_checked_at = ? WHERE id = ?", (now, review_id))
+
+    if i % COMMIT_EVERY == 0:
+        conn.commit()
+    time.sleep(0.1)  # Rate limit
+
+conn.commit()
+
+c.execute("SELECT COUNT(*) FROM reviews WHERE closed = 1")
+closed_count = c.fetchone()[0]
+print(f"Done. Checked {len(rows)} restaurants ({not_found} not found on Places). "
+      f"{newly_closed} newly closed; {closed_count} closed in total.")
+
+conn.close()

--- a/check_closures.py
+++ b/check_closures.py
@@ -13,20 +13,28 @@ COMMIT_EVERY = 25
 conn = sqlite3.connect('reviews.db')
 c = conn.cursor()
 
-# Google Maps API key
-api_key = os.environ.get('GOOGLE_MAPS_API_KEY')
-if not api_key:
+# Google Maps API key (Places-enabled; falls back to the legacy shared key)
+KEY_NAMES = ('GOOGLE_MAPS_API_KEY_PLACES', 'GOOGLE_MAPS_API_KEY')
+
+
+def load_api_key():
+    for name in KEY_NAMES:
+        if os.environ.get(name):
+            return os.environ[name]
     try:
         with open('.env') as f:
             for line in f:
-                if line.startswith('GOOGLE_MAPS_API_KEY='):
-                    api_key = line.strip().split('=', 1)[1]
-                    break
+                name, _, value = line.strip().partition('=')
+                if name in KEY_NAMES and value:
+                    return value
     except FileNotFoundError:
         pass
+    return None
 
+
+api_key = load_api_key()
 if not api_key:
-    print("ERROR: GOOGLE_MAPS_API_KEY not found")
+    print("ERROR: GOOGLE_MAPS_API_KEY_PLACES not found")
     exit(1)
 
 # Add closure columns if they don't exist

--- a/generate_map.py
+++ b/generate_map.py
@@ -6,7 +6,7 @@ conn = sqlite3.connect('reviews.db')
 c = conn.cursor()
 
 # Get the reviews data (exclude rows with NULL coordinates)
-c.execute('SELECT location_lat, location_long, sentiment, title, url FROM reviews WHERE location_lat IS NOT NULL AND location_long IS NOT NULL')
+c.execute('SELECT location_lat, location_long, sentiment, title, url, COALESCE(closed, 0), closed_date FROM reviews WHERE location_lat IS NOT NULL AND location_long IS NOT NULL')
 reviews = c.fetchall()
 
 # Create a map centered on the first review
@@ -32,9 +32,14 @@ def get_color(sentiment):
 
 # Add markers for each review
 for review in reviews:
-    lat, lon, sentiment, title, url = review
-    color = get_color(sentiment)
-    popup_html = f'<a href="{url}">{title}</a>'
+    lat, lon, sentiment, title, url, closed, closed_date = review
+    if closed:
+        color = 'gray'
+        closed_label = f'[CLOSED since {closed_date}]' if closed_date else '[CLOSED]'
+        popup_html = f'<a href="{url}"><s>{title}</s> {closed_label}</a>'
+    else:
+        color = get_color(sentiment)
+        popup_html = f'<a href="{url}">{title}</a>'
     marker = folium.Marker(location=[lat, lon], icon=folium.Icon(color=color), popup=folium.Popup(html=popup_html, max_width=2650))
     marker.add_to(m)
 

--- a/get_locations.py
+++ b/get_locations.py
@@ -9,20 +9,28 @@ conn = sqlite3.connect('reviews.db')
 c = conn.cursor()
 _c = conn.cursor()
 
-# Google Maps API key
-api_key = os.environ.get('GOOGLE_MAPS_API_KEY')
-if not api_key:
+# Google Maps API key (Geocoding-enabled; falls back to the legacy shared key)
+KEY_NAMES = ('GOOGLE_MAPS_API_KEY_GEOCODE', 'GOOGLE_MAPS_API_KEY')
+
+
+def load_api_key():
+    for name in KEY_NAMES:
+        if os.environ.get(name):
+            return os.environ[name]
     try:
         with open('.env') as f:
             for line in f:
-                if line.startswith('GOOGLE_MAPS_API_KEY='):
-                    api_key = line.strip().split('=', 1)[1]
-                    break
+                name, _, value = line.strip().partition('=')
+                if name in KEY_NAMES and value:
+                    return value
     except FileNotFoundError:
         pass
+    return None
 
+
+api_key = load_api_key()
 if not api_key:
-    print("ERROR: GOOGLE_MAPS_API_KEY not found")
+    print("ERROR: GOOGLE_MAPS_API_KEY_GEOCODE not found")
     exit(1)
 
 # Create location columns if they don't exist


### PR DESCRIPTION
## Summary

Supersedes #6 (couldn't update that branch non-destructively, so this is a clean rework on top of current `main`). Closes #2.

- Adds `check_closures.py`: queries the Places *Find Place* API for each restaurant's `business_status` and marks permanently closed ones
- Closed restaurants render as grey markers with a strikethrough title and `[CLOSED since <date>]` label
- Weekly CI step added, with `continue-on-error` so a Places failure never blocks the map update

### Improvements over #6
- **ToS compliance**: recheck window is 30 days (was 90) — Google Maps Platform terms cap caching of Places data at 30 days
- **Failure-tolerant**: per-row `closure_checked_at` timestamps with incremental commits replace the global "reset everything then recheck" pass, so a mid-run crash resumes instead of wiping all statuses
- **`closed_date` is actually populated** (the original added the column but never wrote it) and shown in the popup
- Places that can't be found keep their previous status instead of being silently marked open
- Quota/auth errors abort the run (no quota burn); transient network errors skip the row for retry next run
- No generated `index.html` churn in the diff — CI regenerates it on merge

### Cost
~594 Find Place requests per 30-day recheck ≈ $10/month, within the $200/month free credit.

## Test plan
- [x] Mocked-API test against a copy of the real DB (594 rows): closure + `closed_date` set together, not-found path, transient-failure resume, freshness no-op all verified
- [x] Live API run (2026-07-02, with the new `GOOGLE_MAPS_API_KEY_PLACES` key): all 594 restaurants checked, 55 permanently closed, 42 not found on Places (kept prior status), zero errors. Both new key secrets are already set on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
