### PR TITLE
Add search and reviewer filtering to the map UI

### DIFF
--- a/generate_map.py
+++ b/generate_map.py
@@ -1,12 +1,20 @@
 import folium
+from folium.plugins import Search
 import sqlite3
 
 # Connect to the database
 conn = sqlite3.connect('reviews.db')
 c = conn.cursor()
 
+# The closure columns only exist once closure tracking has run, so degrade
+# gracefully when they are absent.
+c.execute("PRAGMA table_info(reviews)")
+columns = [column[1] for column in c.fetchall()]
+closed_select = "COALESCE(closed, 0), closed_date" if 'closed' in columns else "0, NULL"
+
 # Get the reviews data (exclude rows with NULL coordinates)
-c.execute('SELECT location_lat, location_long, sentiment, title, url FROM reviews WHERE location_lat IS NOT NULL AND location_long IS NOT NULL')
+c.execute(f'SELECT location_lat, location_long, sentiment, title, url, author, {closed_select} '
+          'FROM reviews WHERE location_lat IS NOT NULL AND location_long IS NOT NULL')
 reviews = c.fetchall()
 
 # Create a map centered on the first review
@@ -17,15 +25,12 @@ m = folium.Map(location=[center_lat, center_long], zoom_start=8)
 title_html = '''
              <h3 align="center" style="font-size:20px"><b>Restaurant Reviews Map</b></h3><h4 align="center" style="font-size:14px"><b>Please forgive any inaccuracies! <a href="https://github.com/ddervs/restaurant-review-map">code</a></b></h4>
              '''
-# title = folium.map.Marker(location=[center_lat, center_long], icon=None, popup=folium.Popup(html=title_html, max_width=2650))
-# title.add_to(m)
-
 m.get_root().html.add_child(folium.Element(title_html))
 
 
 # Define a color function based on sentiment value.
-# Sentiment is on a [0, 1] scale (0.5 = mixed), so the old `< 0` check made
-# every marker green.
+# Sentiment is on a [0, 1] scale (0.5 = mixed), so red is a pan, orange is
+# mixed and green is a recommendation.
 def get_color(sentiment):
     if sentiment < 0.4:
         return 'red'
@@ -34,13 +39,60 @@ def get_color(sentiment):
     else:
         return 'green'
 
+
+def get_reviewer(author):
+    author = author or ''
+    if 'Grace Dent' in author:
+        return 'Grace Dent'
+    if 'Rayner' in author:
+        return 'Jay Rayner'
+    return 'Other contributors'
+
+
+# One toggleable layer per reviewer, so the layer control acts as a filter
+reviewer_groups = {}
+for reviewer in ('Grace Dent', 'Jay Rayner', 'Other contributors'):
+    reviewer_groups[reviewer] = folium.FeatureGroup(name=reviewer, show=True).add_to(m)
+
+# Invisible point layer that only exists to power the search box
+search_features = []
+
 # Add markers for each review
 for review in reviews:
-    lat, lon, sentiment, title, url = review
-    color = get_color(sentiment)
-    popup_html = f'<a href="{url}">{title}</a>'
-    marker = folium.Marker(location=[lat, lon], icon=folium.Icon(color=color), popup=folium.Popup(html=popup_html, max_width=2650))
-    marker.add_to(m)
+    lat, lon, sentiment, title, url, author, closed, closed_date = review
+    if closed:
+        color = 'gray'
+        closed_label = f'[CLOSED since {closed_date}]' if closed_date else '[CLOSED]'
+        popup_html = f'<a href="{url}"><s>{title}</s> {closed_label}</a>'
+    else:
+        color = get_color(sentiment)
+        popup_html = f'<a href="{url}">{title}</a>'
+    marker = folium.Marker(location=[lat, lon], icon=folium.Icon(color=color),
+                           popup=folium.Popup(html=popup_html, max_width=2650),
+                           tooltip=title)
+    marker.add_to(reviewer_groups[get_reviewer(author)])
+    search_features.append({
+        "type": "Feature",
+        "geometry": {"type": "Point", "coordinates": [lon, lat]},
+        "properties": {"name": title},
+    })
+
+search_index = folium.GeoJson(
+    {"type": "FeatureCollection", "features": search_features},
+    name="search index",
+    control=False,
+    marker=folium.CircleMarker(radius=0, weight=0, fill=False),
+).add_to(m)
+
+Search(
+    layer=search_index,
+    search_label='name',
+    placeholder='Search restaurants...',
+    collapsed=True,
+    zoom=16,
+).add_to(m)
+
+folium.LayerControl(collapsed=False).add_to(m)
 
 # Save the map as an HTML file
 m.save('index.html')


### PR DESCRIPTION
## Summary

Addresses the main asks in #3:

- **Search by restaurant name**: a magnifying-glass search box (Leaflet.Control.Search) that autocompletes across all 594 restaurants and zooms to the match. It's backed by an invisible zero-radius point layer that acts purely as a search index, so the visible markers stay exactly as they were.
- **Filter by reviewer**: the layer control (top right, expanded) has a checkbox each for Grace Dent, Jay Rayner and Other contributors — untick to hide.
- **Hover tooltips** with the restaurant name on every marker.
- Sentiment "filtering" is visual via the red/orange/green markers from #8 rather than a checkbox; date-range and region filters from the issue are left for later (they'd need a custom JS control, not stock folium).

`generate_map.py` detects the closure columns with a PRAGMA check, so it renders grey `[CLOSED]` markers when #7's closure tracking has run and degrades gracefully when it hasn't.

## Merge order

**Stacked on #8** (base is `improve-sentiment`; GitHub will retarget to `main` when #8 merges). Best merged **after** #7 and #8. If git reports a conflict in `generate_map.py` against #7, take this branch's version wholesale — it already includes the closure rendering.

## Test plan
- [x] Generated locally against the rescored DB: 594 markers across the three reviewer layers (469 green / 60 orange / 65 red), layer control lists all three groups, search plugin loaded with all 594 names
- [x] Regenerated `index.html` excluded from the diff — CI rebuilds it on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)