### PR TITLE
Fix FT dedupe broken by feed syndication parameter

### DIFF
--- a/download_ft_reviews.py
+++ b/download_ft_reviews.py
@@ -2,6 +2,7 @@ import requests
 import sqlite3
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from urllib.parse import urldefrag, urlsplit, urlunsplit
 
 # Connect to the database
 conn = sqlite3.connect('reviews.db')
@@ -12,6 +13,16 @@ def is_review(title):
     title_lower = title.lower()
     return 'review' in title_lower or 'visits' in title_lower
 
+def canonical_url(url):
+    """Drop query strings and fragments.
+
+    The FT feed tags links with a per-feed syndication parameter
+    (e.g. ?syn-25a6b1a6=1) that changes over time, so the raw link is
+    useless for deduplication.
+    """
+    parts = urlsplit(urldefrag(url).url)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, '', ''))
+
 # Fetch FT RSS feed
 print("Fetching FT RSS feed...")
 url = "https://www.ft.com/jay-rayner?format=rss"
@@ -20,14 +31,19 @@ root = ET.fromstring(resp.content)
 
 # Get existing URLs
 c.execute("SELECT url FROM reviews WHERE url LIKE '%ft.com%'")
-existing_urls = {row[0] for row in c.fetchall()}
+existing_urls = {canonical_url(row[0]) for row in c.fetchall()}
 print(f"Existing FT reviews in DB: {len(existing_urls)}")
+
+# Titles are UNIQUE in the schema, so guard against re-runs where the URL has
+# changed but the article has not
+c.execute("SELECT title FROM reviews")
+existing_titles = {row[0] for row in c.fetchall()}
 
 # Process RSS items
 added = 0
 for item in root.findall('.//item'):
     title = item.find('title').text
-    link = item.find('link').text
+    link = canonical_url(item.find('link').text)
     pub_date = item.find('pubDate').text
 
     # Skip if not a review
@@ -35,7 +51,7 @@ for item in root.findall('.//item'):
         continue
 
     # Skip if already in database
-    if link in existing_urls:
+    if link in existing_urls or title in existing_titles:
         continue
 
     print(f"New review: {title[:60]}...")
@@ -51,6 +67,8 @@ for item in root.findall('.//item'):
     c.execute('''INSERT INTO reviews (date, title, text, url, author)
                  VALUES (?, ?, ?, ?, ?)''',
               (date_str, title, '', link, 'Jay Rayner'))
+    existing_urls.add(link)
+    existing_titles.add(title)
     added += 1
 
 conn.commit()


### PR DESCRIPTION
## Problem

The scheduled **Update Reviews** run on 2026-07-20 failed:

```
File "download_ft_reviews.py", line 51, in <module>
    c.execute('''INSERT INTO reviews (date, title, text, url, author)
sqlite3.IntegrityError: UNIQUE constraint failed: reviews.title
```

The FT RSS feed now appends a per-feed syndication parameter to every link:

```
https://www.ft.com/content/b5eba584-...?syn-25a6b1a6=1
```

Stored URLs have no query string, so `if link in existing_urls` never matched. The script treated all 20 reviews in the feed as new and blew up on the fourth one (Teal by Sally Abé, already in the DB).

Side effect: the three genuinely new reviews (Appalachia 4 Jul, Margaret's 11 Jul, Jul's 18 Jul) were never added, since the script dies before `conn.commit()`.

## Fix

- Strip query string and fragment via `canonical_url()` before comparing and before storing, so URLs stay in the same canonical form already used throughout the DB.
- Also skip on title as a second guard — titles are `UNIQUE` in the schema, so a future URL-shape change degrades to a skip rather than a crash.
- Update both sets in the loop so duplicates within a single feed can't collide either.

## Testing

Ran the patched script against a copy of the production DB, stubbing the fetch with a live capture of the feed:

```
Fetching FT RSS feed...
Existing FT reviews in DB: 55
New review: Jul's, London: strange food at serious prices — restaurant r...
New review: Margaret's, Cambridge: comfort with excellent tailoring — re...
New review: Jay Rayner reviews Appalachia, London: 'A refreshed take on ...

Done: 3 new FT reviews added
```

Second run on the same DB is a clean no-op:

```
Existing FT reviews in DB: 58

Done: 0 new FT reviews added
```

Stored URLs are canonical (no `syn-` param). Merging to main triggers the workflow, which will backfill the three missing reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2Yfwi8UGgszmD3UvgNN3m